### PR TITLE
chaossystems-i3: Drop post install of python libararies and tools.

### DIFF
--- a/chaossystems-i3/build.gradle
+++ b/chaossystems-i3/build.gradle
@@ -1,6 +1,6 @@
 ospackage {
     packageName = 'chaossystems-i3'
-    version = '1.5.4'
+    version = '1.6.0'
     release = '1'
     os = LINUX
 

--- a/chaossystems-i3/scripts/post-install.sh
+++ b/chaossystems-i3/scripts/post-install.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-pip install netifaces psutil requests powerline-status
 mkdir -p /opt
 git clone git://github.com/tobi-wan-kenobi/bumblebee-status /opt/bumblebee-status
 ln -s /opt/bumblebee-status/bumblebee-status /usr/local/bin/bumblebee-status

--- a/chaossystems-i3/scripts/pre-uninstall.sh
+++ b/chaossystems-i3/scripts/pre-uninstall.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
-pip uninstall netifaces psutil requests powerline-status
 rm -rf /opt/bumblebee-status
 rm -f /usr/local/bin/bumblebee-status


### PR DESCRIPTION
This mostly is about removing the installation of powerline-status and
related tools as part of the post-install of this package. It was
causing more issues than it was helping and doesn't seem like the best
approach.